### PR TITLE
[Oxidize DAGCircuit] Add: ancestors, descendants, bfs_successors to oxidized `DAGCircuit`

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -3595,18 +3595,18 @@ impl DAGCircuit {
 
     /// Returns an iterator of the ancestors indices of a node.
     pub fn ancestors<'a>(&'a self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + 'a {
-        core_ancestors(&self.dag, node)
+        core_ancestors(&self.dag, node).filter(move |next| next != &node)
     }
 
     /// Returns an iterator of the descendants of a node as DAGOpNodes and DAGOutNodes.
     pub fn descendants<'a>(&'a self, node: NodeIndex) -> impl Iterator<Item= NodeIndex> + 'a {
-        core_descendants(&self.dag, node)
+        core_descendants(&self.dag, node).filter(move |next| next != &node)
     }
 
     /// Returns an iterator of tuples of (DAGNode, [DAGNodes]) where the DAGNode is the current node
     /// and [DAGNode] is its successors in  BFS order.
     pub fn bfs_successors<'a>(&'a self, node: NodeIndex) -> impl Iterator<Item = (NodeIndex, Vec<NodeIndex>)> + 'a {
-        core_bfs_successors(&self.dag, node)
+        core_bfs_successors(&self.dag, node).filter(move |(_, others)| !others.is_empty())
     }
 
     fn unpack_into(&self, py: Python, id: NodeIndex, weight: &NodeType) -> PyResult<Py<PyAny>> {

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -1925,7 +1925,6 @@ def _format(operand):
         // ))
     }
 
-
     /// Yield nodes in topological order.
     ///
     /// Args:
@@ -2808,40 +2807,46 @@ def _format(operand):
     }
 
     /// Returns set of the ancestors of a node as DAGOpNodes and DAGInNodes.
-    #[pyo3(name="ancestors")]
+    #[pyo3(name = "ancestors")]
     fn py_ancestors(&self, py: Python, node: &DAGNode) -> PyResult<Py<PySet>> {
-        let ancestors: PyResult<Vec<PyObject>> = self.ancestors(node.node.unwrap())
-            .map(|node| self.get_node(py, node)).collect();
+        let ancestors: PyResult<Vec<PyObject>> = self
+            .ancestors(node.node.unwrap())
+            .map(|node| self.get_node(py, node))
+            .collect();
         Ok(PySet::new_bound(py, &ancestors?)?.unbind())
     }
 
     /// Returns set of the descendants of a node as DAGOpNodes and DAGOutNodes.
-    #[pyo3(name="descendants")]
+    #[pyo3(name = "descendants")]
     fn py_descendants(&self, py: Python, node: &DAGNode) -> PyResult<Py<PySet>> {
-        let descendants: PyResult<Vec<PyObject>> = self.descendants(node.node.unwrap())
-            .map(|node| self.get_node(py, node)).collect();
+        let descendants: PyResult<Vec<PyObject>> = self
+            .descendants(node.node.unwrap())
+            .map(|node| self.get_node(py, node))
+            .collect();
         Ok(PySet::new_bound(py, &descendants?)?.unbind())
     }
 
     /// Returns an iterator of tuples of (DAGNode, [DAGNodes]) where the DAGNode is the current node
     /// and [DAGNode] is its successors in  BFS order.
-    #[pyo3(name="bfs_successors")]
+    #[pyo3(name = "bfs_successors")]
     fn py_bfs_successors(&self, py: Python, node: &DAGNode) -> PyResult<Py<PyIterator>> {
-        let successor_index: PyResult<Vec<(PyObject, Vec<PyObject>)>> = self.bfs_successors(node.node.unwrap()).map(|(node, nodes)| -> PyResult<(PyObject, Vec<PyObject>)> {
-           Ok((
-            self.get_node(py, node)?,
-            nodes
-                .iter()
-                .map(|sub_node| self.get_node(py, *sub_node))
-                .collect::<PyResult<Vec<_>>>()?
-            ))
-        }).collect();
+        let successor_index: PyResult<Vec<(PyObject, Vec<PyObject>)>> = self
+            .bfs_successors(node.node.unwrap())
+            .map(|(node, nodes)| -> PyResult<(PyObject, Vec<PyObject>)> {
+                Ok((
+                    self.get_node(py, node)?,
+                    nodes
+                        .iter()
+                        .map(|sub_node| self.get_node(py, *sub_node))
+                        .collect::<PyResult<Vec<_>>>()?,
+                ))
+            })
+            .collect();
         Ok(PyList::new_bound(py, successor_index?)
             .into_any()
             .iter()?
             .unbind())
     }
-    
 
     /// Returns iterator of the successors of a node that are
     /// connected by a quantum edge as DAGOpNodes and DAGOutNodes.
@@ -3599,13 +3604,16 @@ impl DAGCircuit {
     }
 
     /// Returns an iterator of the descendants of a node as DAGOpNodes and DAGOutNodes.
-    pub fn descendants<'a>(&'a self, node: NodeIndex) -> impl Iterator<Item= NodeIndex> + 'a {
+    pub fn descendants<'a>(&'a self, node: NodeIndex) -> impl Iterator<Item = NodeIndex> + 'a {
         core_descendants(&self.dag, node).filter(move |next| next != &node)
     }
 
     /// Returns an iterator of tuples of (DAGNode, [DAGNodes]) where the DAGNode is the current node
     /// and [DAGNode] is its successors in  BFS order.
-    pub fn bfs_successors<'a>(&'a self, node: NodeIndex) -> impl Iterator<Item = (NodeIndex, Vec<NodeIndex>)> + 'a {
+    pub fn bfs_successors<'a>(
+        &'a self,
+        node: NodeIndex,
+    ) -> impl Iterator<Item = (NodeIndex, Vec<NodeIndex>)> + 'a {
         core_bfs_successors(&self.dag, node).filter(move |(_, others)| !others.is_empty())
     }
 

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -25,8 +25,8 @@ mod interner;
 
 use pyo3::prelude::*;
 use pyo3::types::{PySequence, PySlice, PyTuple};
-use std::ops::Deref;
 use pyo3::DowncastError;
+use std::ops::Deref;
 
 /// A private enumeration type used to extract arguments to pymethod
 /// that may be either an index or a slice
@@ -51,18 +51,15 @@ pub struct TupleLikeArg<'py> {
 impl<'py> FromPyObject<'py> for TupleLikeArg<'py> {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
         let value = match ob.downcast::<PySequence>() {
-            Ok(seq) => {seq.to_tuple()?}
-            Err(_) => {
-                PyTuple::new_bound(
-                    ob.py(),
-                    ob.iter()?
-                        .map(|o| Ok(o?.unbind()))
-                        .collect::<PyResult<Vec<PyObject>>>()?)
-            }
+            Ok(seq) => seq.to_tuple()?,
+            Err(_) => PyTuple::new_bound(
+                ob.py(),
+                ob.iter()?
+                    .map(|o| Ok(o?.unbind()))
+                    .collect::<PyResult<Vec<PyObject>>>()?,
+            ),
         };
-        Ok(TupleLikeArg {
-            value,
-        })
+        Ok(TupleLikeArg { value })
     }
 }
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [x] I have added the tests to cover my changes.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
-->

### Summary
These commits add the `ancestors`, `descendants` and `bfs_successors` to the oxidiced `DAGCircuit`

### Details and comments
[WIP]

