### PR TITLE
Add `edges` method to `DAGCircuit`

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -2598,7 +2598,7 @@ def _format(operand):
     /// no nodes are specified all edges from the graph are returned.
     ///
     /// Args:
-    /// nodes(DAGOpNode, DAGInNode, or DAGOutNode|list(DAGOpNode, DAGInNode, or DAGOutNode):
+    ///     nodes(DAGOpNode, DAGInNode, or DAGOutNode|list(DAGOpNode, DAGInNode, or DAGOutNode):
     ///         Either a list of nodes or a single input node. If none is specified,
     ///         all edges are returned from the graph.
     ///


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Implements `edges` method in Rust. I want to try to make the implementation more iterator-y, but I think I will prioritize getting started with the other methods to have at least a base implementation in place. Suggestions welcome.

### Details and comments
- Including @jakelishman as a co-author because he's helped a lot. If there's any bad code, it's mine.
- The original signature returns a `PyIterator` directly but I see that most other methods return a `PyResult`, so I went with that option. Let me know if this was for a specific reason and I can change it.