### PR TITLE
Implement dag.draw() method

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -3336,14 +3336,14 @@ def _format(operand):
     ///     otherwise None.
     #[pyo3(signature=(scale=0.7, filename=None, style="color"))]
     fn draw<'py>(
-        &self,
+        slf: PyRef<'py, Self>,
         py: Python<'py>,
         scale: f64,
         filename: Option<&str>,
         style: &str,
     ) -> PyResult<Bound<'py, PyAny>> {
         let module = PyModule::import_bound(py, "qiskit.visualization.dag_visualization")?;
-        module.call_method1("dag_drawer", (scale, filename, style))
+        module.call_method1("dag_drawer", (slf, scale, filename, style))
     }
 
     fn _to_dot<'py>(

--- a/crates/circuit/src/dot_utils.rs
+++ b/crates/circuit/src/dot_utils.rs
@@ -21,8 +21,7 @@ use std::io::prelude::*;
 use crate::dag_circuit::{DAGCircuit, Wire};
 use pyo3::prelude::*;
 use rustworkx_core::petgraph::visit::{
-    Data, EdgeRef, GraphBase, GraphProp, IntoEdgeReferences, IntoNodeReferences, NodeIndexable,
-    NodeRef,
+    EdgeRef, IntoEdgeReferences, IntoNodeReferences, NodeIndexable, NodeRef,
 };
 
 static TYPE: [&str; 2] = ["graph", "digraph"];

--- a/crates/circuit/src/dot_utils.rs
+++ b/crates/circuit/src/dot_utils.rs
@@ -1,15 +1,15 @@
-// Licensed under the Apache License, Version 2.0 (the "License"); you may
-// not use this file except in compliance with the License. You may obtain
-// a copy of the License at
+// This code is part of Qiskit.
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// (C) Copyright IBM 2022
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations
-// under the License.
+// This code is licensed under the Apache License, Version 2.0. You may
+// obtain a copy of this license in the LICENSE.txt file in the root directory
+// of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
 //
+// Any modifications or derivative works of this code must retain this
+// copyright notice, and modified files need to carry a notice indicating
+// that they have been altered from the originals.
+
 // This module is forked from rustworkx at:
 // https://github.com/Qiskit/rustworkx/blob/c4256daf96fc3c08c392450ed33bc0987cdb15ff/src/dot_utils.rs
 // and has been modified to generate a dot file from a Rust DAGCircuit instead

--- a/crates/circuit/src/dot_utils.rs
+++ b/crates/circuit/src/dot_utils.rs
@@ -1,0 +1,109 @@
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+//
+// This module is forked from rustworkx at:
+// https://github.com/Qiskit/rustworkx/blob/c4256daf96fc3c08c392450ed33bc0987cdb15ff/src/dot_utils.rs
+// and has been modified to generate a dot file from a Rust DAGCircuit instead
+// of a rustworkx PyGraph object
+
+use std::collections::BTreeMap;
+use std::io::prelude::*;
+
+use crate::dag_circuit::{DAGCircuit, Wire};
+use pyo3::prelude::*;
+use rustworkx_core::petgraph::visit::{
+    Data, EdgeRef, GraphBase, GraphProp, IntoEdgeReferences, IntoNodeReferences, NodeIndexable,
+    NodeRef,
+};
+
+static TYPE: [&str; 2] = ["graph", "digraph"];
+static EDGE: [&str; 2] = ["--", "->"];
+
+pub fn build_dot<T>(
+    py: Python,
+    dag: &DAGCircuit,
+    file: &mut T,
+    graph_attrs: Option<BTreeMap<String, String>>,
+    node_attrs: Option<PyObject>,
+    edge_attrs: Option<PyObject>,
+) -> PyResult<()>
+where
+    T: Write,
+{
+    let graph = &dag.dag;
+    writeln!(file, "{} {{", TYPE[graph.is_directed() as usize])?;
+    if let Some(graph_attr_map) = graph_attrs {
+        for (key, value) in graph_attr_map.iter() {
+            writeln!(file, "{}={} ;", key, value)?;
+        }
+    }
+
+    for node in graph.node_references() {
+        let node_weight = dag.get_node(py, node.id())?;
+        writeln!(
+            file,
+            "{} {};",
+            graph.to_index(node.id()),
+            attr_map_to_string(py, node_attrs.as_ref(), node_weight)?
+        )?;
+    }
+    for edge in graph.edge_references() {
+        let edge_weight = match edge.weight() {
+            Wire::Qubit(qubit) => dag.qubits.get(*qubit).unwrap(),
+            Wire::Clbit(clbit) => dag.clbits.get(*clbit).unwrap(),
+        };
+        writeln!(
+            file,
+            "{} {} {} {};",
+            graph.to_index(edge.source()),
+            EDGE[graph.is_directed() as usize],
+            graph.to_index(edge.target()),
+            attr_map_to_string(py, edge_attrs.as_ref(), edge_weight)?
+        )?;
+    }
+    writeln!(file, "}}")?;
+    Ok(())
+}
+
+static ATTRS_TO_ESCAPE: [&str; 2] = ["label", "tooltip"];
+
+/// Convert an attr map to an output string
+fn attr_map_to_string<'a, T: ToPyObject>(
+    py: Python,
+    attrs: Option<&'a PyObject>,
+    weight: T,
+) -> PyResult<String> {
+    if attrs.is_none() {
+        return Ok("".to_string());
+    }
+    let attr_callable = |node: T| -> PyResult<BTreeMap<String, String>> {
+        let res = attrs.unwrap().call1(py, (node.to_object(py),))?;
+        res.extract(py)
+    };
+
+    let attrs = attr_callable(weight)?;
+    if attrs.is_empty() {
+        return Ok("".to_string());
+    }
+    let attr_string = attrs
+        .iter()
+        .map(|(key, value)| {
+            if ATTRS_TO_ESCAPE.contains(&key.as_str()) {
+                format!("{}=\"{}\"", key, value)
+            } else {
+                format!("{}={}", key, value)
+            }
+        })
+        .collect::<Vec<String>>()
+        .join(", ");
+    Ok(format!("[{}]", attr_string))
+}

--- a/crates/circuit/src/lib.rs
+++ b/crates/circuit/src/lib.rs
@@ -20,6 +20,7 @@ pub mod parameter_table;
 
 mod bit_data;
 mod dag_node;
+mod dot_utils;
 mod error;
 mod interner;
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

This commit implements the dag.draw() method for the new rust dagcircuit struct. To accomplish this first the dot_utils.rs module from rustworkx is forked and included in qiskit circuit crate. This module is used to generate a dot file using python callbacks, it is modified to work with the dagcircuit types directly. Eventually this can be ported to rustworkx-core and made more generic, but honestly there isn't too much of a need because that will require a lot of boiler plate on the caller side here. With a method to generate a dot file from rust for a dagcircuit implement this is then exposed to Python as a new private method `._to_dot()` which will return a dot file string. The Python space dag drawer is then modified to instead of relying on rustworkx's graphviz_draw() method to instead call `dag._to_dot()` and manually pass that to graphviz to generate a visualization. This is essentially what rustworkx's graphviz_draw() is already doing under the covers. Then the final piece to implement the rust implementation of the draw() method is to use pyo3 to call the python space dag_drawer() function which is how the previous python implementation's method worked.

### Details and comments