### PR TITLE
Add `remove` methods for `ancestors`, `descendants`, `nonancestors`, `nondescendants` in `DAGCircuit`

### DIFF
--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -2953,7 +2953,7 @@ def _format(operand):
 
     /// Remove all of the non-ancestors operation nodes of node.
     fn remove_nonancestors_of(&mut self, node: &DAGNode) -> PyResult<()> {
-        let ancestors: Vec<_> = core_ancestors(&self.dag, node.node.unwrap())
+        let ancestors: HashSet<_> = core_ancestors(&self.dag, node.node.unwrap())
             .filter(|next| {
                 next != &node.node.unwrap()
                     && match self.dag.node_weight(*next) {
@@ -2965,7 +2965,7 @@ def _format(operand):
         let non_ancestors: Vec<_> = self
             .dag
             .node_indices()
-            .filter(|node_id| ancestors.iter().find(|anc| *anc == node_id).is_none())
+            .filter(|node_id| !ancestors.contains(node_id))
             .collect();
         for na in non_ancestors {
             self.dag.remove_node(na);
@@ -2975,7 +2975,7 @@ def _format(operand):
 
     /// Remove all of the non-descendants operation nodes of node.
     fn remove_nondescendants_of(&mut self, node: &DAGNode) -> PyResult<()> {
-        let descendants: Vec<_> = core_descendants(&self.dag, node.node.unwrap())
+        let descendants: HashSet<_> = core_descendants(&self.dag, node.node.unwrap())
             .filter(|next| {
                 next != &node.node.unwrap()
                     && match self.dag.node_weight(*next) {
@@ -2987,7 +2987,7 @@ def _format(operand):
         let non_descendants: Vec<_> = self
             .dag
             .node_indices()
-            .filter(|node_id| descendants.iter().find(|desc| *desc == node_id).is_none())
+            .filter(|node_id| !descendants.contains(node_id))
             .collect();
         for nd in non_descendants {
             self.dag.remove_node(nd);

--- a/crates/circuit/src/dag_circuit.rs
+++ b/crates/circuit/src/dag_circuit.rs
@@ -2919,16 +2919,16 @@ def _format(operand):
 
     /// Remove all of the ancestor operation nodes of node.
     fn remove_ancestors_of(&mut self, node: &DAGNode) -> PyResult<()> {
-        let dag_binding = self.dag.clone();
-        for ancestor in core_ancestors(&dag_binding, node.node.unwrap())
-            .filter(|next| next != &node.node.unwrap())
-            .filter(|next| match dag_binding.node_weight(*next) {
-                Some(NodeType::Operation(_)) => true,
-                _ => false,
+        let ancestors: Vec<_> = core_ancestors(&self.dag, node.node.unwrap())
+            .filter(|next| {
+                next != &node.node.unwrap()
+                    && match self.dag.node_weight(*next) {
+                        Some(NodeType::Operation(_)) => true,
+                        _ => false,
+                    }
             })
-        {
-            self.dag.remove_node(ancestor);
-        }
+            .collect();
+        ancestors.iter().map(|a| self.dag.remove_node(*a));
         Ok(())
     }
 


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Implements the following `DAGCircuit` methods in Rust:

- `remove_ancestors_of`
- `remove_descendants_of`
- `remove_nonancestors_of`
- `remove_nondescendants_of`

### Details and comments


