### PR TITLE
Oxidize dag vars

### DIFF
--- a/crates/circuit/src/dag_node.rs
+++ b/crates/circuit/src/dag_node.rs
@@ -445,6 +445,7 @@ impl DAGOpNode {
 }
 
 /// Object to represent an incoming wire node in the DAGCircuit.
+#[derive(Clone, Debug)]
 #[pyclass(module = "qiskit._accelerate.circuit", extends=DAGNode)]
 pub struct DAGInNode {
     #[pyo3(get)]
@@ -497,6 +498,7 @@ impl DAGInNode {
 }
 
 /// Object to represent an outgoing wire node in the DAGCircuit.
+#[derive(Clone, Debug)]
 #[pyclass(module = "qiskit._accelerate.circuit", extends=DAGNode)]
 pub struct DAGOutNode {
     #[pyo3(get)]


### PR DESCRIPTION
[The code in this PR is preliminary and not worth reviewing now. I opened to PR to get some understanding and ideas written in comments.]

In the current Python implementation of `DAGCircuit`, variables are instances of Python `expr.Var`.

In Rust, the first step to handling variables is to store and work with the corresponding `PyObject`
rather than porting the Python `class` to a Rust `struct`.

In dagcircuit.py the input nodes of all "wires" are stored in `input_map` of type `OrderedDict`.
Information on what kind of wire, qubit, clbit, var is stored in each element in the map. The
same is doen for output nodes.

In the latest dagcircuit.rs, the container `input_map` is split into containers `qubit_input_map`,
`clbit_input_map`, and `var_input_map`. The first two are of type `IndexMap`, which is an ordered dictionary
(in typical Rust fashion, the documentation buries the lede on the nature of `IndexMap`.) The third
is a struct wrapping `Py<PyDict>` because `PyObject` cannot be the key to `IndexMap`.

A good bit of handling `Var`s is already ported and present in dagcircuit.rs. There appears to be a small
amount left to do. This assumes that "porting" means we are still using the Python implementation of
`Var` via `PyObject`. There are a few comments in dagcircuit.rs stating that the goal is to eventually
port `Var` to Rust which will enable all kinds of efficiencies, including storing them (or references)
in `IndexMap`.

In particular what this PR will *not* do is
* Change the represenation of Vars in dagcircuit.rs
* Make any large changes to the data structures in dagcircuit.rs

What this PR *will* do

- [ ]  Add a type in Rust corresponding to elements in `_vars_info` in Python and add a field with a container of these to the Rust `DAGCircuit`.
- [ ] Add code to populate `_vars_info`. This is done when adding them as a "wire".
- [ ]  Add the methods that extract information from `_vars_info`.
- [ ] Repeat the items above for `vars_by_type`.
